### PR TITLE
Extract operator to its own package, move controller tests to their respective packages

### DIFF
--- a/cmd/zfs-sync-operator/backup_test.go
+++ b/cmd/zfs-sync-operator/backup_test.go
@@ -23,6 +23,8 @@ func TestBackup(t *testing.T) {
 	}
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		assert.NoError(collect, TestEnv.Client().Get(TestEnv.Context(), client.ObjectKeyFromObject(&backup), &backup))
-		assert.Equal(collect, "Ready", backup.Status.State)
+		if assert.NotNil(collect, backup.Status) {
+			assert.Equal(collect, "Ready", backup.Status.State)
+		}
 	}, 1*time.Second, 10*time.Millisecond)
 }

--- a/cmd/zfs-sync-operator/main.go
+++ b/cmd/zfs-sync-operator/main.go
@@ -3,183 +3,19 @@ package main
 
 import (
 	"context"
-	"errors"
-	"flag"
 	"fmt"
-	"io"
-	"log/slog"
-	"net"
 	"os"
 	"os/signal"
-	"runtime"
-	"time"
 
-	"github.com/go-logr/logr"
-	"github.com/johnstarich/zfs-sync-operator/internal/backup"
-	"github.com/johnstarich/zfs-sync-operator/internal/name"
-	"github.com/johnstarich/zfs-sync-operator/internal/pool"
-	apiruntime "k8s.io/apimachinery/pkg/runtime"
-	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
-	clientconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/config"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/source"
+	"github.com/johnstarich/zfs-sync-operator/internal/operator"
 )
 
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
-	err := runWithArgs(ctx, os.Args[1:], os.Stdout)
+	err := operator.Run(ctx, os.Args[1:], os.Stdout)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-}
-
-func runWithArgs(ctx context.Context, args []string, out io.Writer) error {
-	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
-	logLevel := flagSet.Int("log-level", 0, "The log level. Defaults to Info. Use -4 for Debug, 4 for Warn, and 8 for Error.")
-	err := flagSet.Parse(args)
-	if err != nil {
-		return err
-	}
-	if len(flagSet.Args()) > 0 {
-		return errors.New(name.Operator + ": this command does not take any arguments")
-	}
-	restConfig, err := clientconfig.GetConfig()
-	if err != nil {
-		return err
-	}
-	const operatorNamespace = name.Operator + "-system"
-	o, err := New(ctx, restConfig, Config{
-		LogHandler: slog.NewJSONHandler(out, &slog.HandlerOptions{Level: slog.Level(*logLevel)}),
-		Namespace:  operatorNamespace,
-	})
-	if err != nil {
-		return err
-	}
-	return o.Wait()
-}
-
-func mustNewScheme() *apiruntime.Scheme {
-	scheme := apiruntime.NewScheme()
-	err := clientsetscheme.AddToScheme(scheme)
-	if err != nil {
-		panic(err)
-	}
-	backup.MustAddToScheme(scheme)
-	pool.MustAddToScheme(scheme)
-	return scheme
-}
-
-// Operator manages the lifecycle of the ZFS offsite backup operator. See the README for more details.
-type Operator struct {
-	manager  manager.Manager
-	startErr chan error
-}
-
-// Config contains configuration to set up an [Operator]
-type Config struct {
-	LogHandler        slog.Handler
-	MetricsPort       string
-	Namespace         string
-	idempotentMetrics bool          // disables safety checks for double metrics registrations
-	maxSessionWait    time.Duration // allows tests to shorten wait times for faster pass/fail results
-}
-
-// New returns a new [Operator]
-func New(ctx context.Context, restConfig *rest.Config, c Config) (*Operator, error) {
-	if c.MetricsPort == "" {
-		c.MetricsPort = "8080"
-	}
-	if c.maxSessionWait == 0 {
-		c.maxSessionWait = 1 * time.Minute
-	}
-	logger := logr.FromSlogHandler(c.LogHandler)
-
-	const reconcilesPerCPU = 2 // Most of the controllers are network-bound, allow a little shared CPU time
-	mgr, err := manager.New(restConfig, manager.Options{
-		LeaderElection:                true,
-		LeaderElectionID:              name.Operator + ".johnstarich.com",
-		LeaderElectionNamespace:       c.Namespace,
-		LeaderElectionReleaseOnCancel: true,
-		Logger:                        logger,
-		BaseContext:                   func() context.Context { return ctx },
-		Scheme:                        mustNewScheme(),
-		Controller: config.Controller{
-			SkipNameValidation:      toPointer(c.idempotentMetrics),
-			MaxConcurrentReconciles: runtime.NumCPU() * reconcilesPerCPU,
-		},
-		Metrics: server.Options{
-			BindAddress: net.JoinHostPort("", c.MetricsPort),
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	{ // Backup
-		ctrl, err := controller.New("backup", mgr, controller.Options{
-			Reconciler: backup.NewReconciler(mgr.GetClient()),
-		})
-		if err != nil {
-			return nil, err
-		}
-		if err := ctrl.Watch(source.Kind(
-			mgr.GetCache(),
-			&backup.Backup{},
-			&handler.TypedEnqueueRequestForObject[*backup.Backup]{},
-			predicate.TypedGenerationChangedPredicate[*backup.Backup]{},
-		)); err != nil {
-			return nil, err
-		}
-	}
-	{ // Pool
-		ctrl, err := controller.New("pool", mgr, controller.Options{
-			Reconciler: pool.NewReconciler(mgr.GetClient(), c.maxSessionWait),
-		})
-		if err != nil {
-			return nil, err
-		}
-		if err := ctrl.Watch(source.Kind(
-			mgr.GetCache(),
-			&pool.Pool{},
-			&handler.TypedEnqueueRequestForObject[*pool.Pool]{},
-			predicate.TypedGenerationChangedPredicate[*pool.Pool]{},
-		)); err != nil {
-			return nil, err
-		}
-	}
-
-	operator := &Operator{
-		manager:  mgr,
-		startErr: make(chan error),
-	}
-	go func() {
-		operator.startErr <- operator.manager.Start(ctx)
-	}()
-	return operator, nil
-}
-
-func (o *Operator) waitUntilLeader() error {
-	select {
-	case err := <-o.startErr:
-		return err
-	case <-o.manager.Elected():
-		return nil
-	}
-}
-
-// Wait blocks until 'o' has terminated, then returns any error encountered
-func (o *Operator) Wait() error {
-	return <-o.startErr
-}
-
-func toPointer[Value any](value Value) *Value {
-	return &value
 }

--- a/config/crd/backup.yaml
+++ b/config/crd/backup.yaml
@@ -35,6 +35,8 @@ spec:
             properties:
               state:
                 type: string
+              reason:
+                type: string
     subresources:
       status: {}
     selectableFields:

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -31,8 +31,8 @@ type Backup struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   Spec   `json:"spec,omitempty"`
-	Status Status `json:"status,omitempty"`
+	Spec   Spec    `json:"spec,omitempty"`
+	Status *Status `json:"status,omitempty"`
 }
 
 // DeepCopyObject implements [runtime.Object]
@@ -46,7 +46,8 @@ type Spec struct {
 
 // Status holds status information for a [Backup]
 type Status struct {
-	State string `json:"state,omitempty"`
+	State  string `json:"state"`
+	Reason string `json:"reason"`
 }
 
 // BackupList is a list of [Backup]. Required to perform a Watch.

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -1,19 +1,27 @@
-package main
+package backup_test
 
 import (
 	"testing"
 	"time"
 
 	zfsbackup "github.com/johnstarich/zfs-sync-operator/internal/backup"
+	"github.com/johnstarich/zfs-sync-operator/internal/envtestrunner"
+	"github.com/johnstarich/zfs-sync-operator/internal/operator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+var TestEnv *envtestrunner.Runner //nolint:gochecknoglobals // The test environment is very expensive to set up, so this performance optimization is required for fast test execution.
+
+func TestMain(m *testing.M) {
+	operator.RunTestMain(m, &TestEnv)
+}
+
 func TestBackup(t *testing.T) {
 	t.Parallel()
-	run := RunTest(t)
+	run := operator.RunTest(t, TestEnv)
 	backup := zfsbackup.Backup{
 		ObjectMeta: metav1.ObjectMeta{Name: "mybackup", Namespace: run.Namespace},
 	}

--- a/internal/backup/reconciler.go
+++ b/internal/backup/reconciler.go
@@ -46,15 +46,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{}, nil
 }
 
-func (r *Reconciler) reconcile(ctx context.Context, backup Backup) (state, reason string, returnedErr error) {
-	/*
-		var source, destination pool.Pool
-		if err := r.client.Get(ctx, client.ObjectKey{Namespace: backup.Namespace, Name: backup.Spec.Source.Name}, &source); err != nil {
-			return "", "", errors.WithMessage(err, "get source Pool")
-		}
-		if err := r.client.Get(ctx, client.ObjectKey{Namespace: backup.Namespace, Name: backup.Spec.Destination.Name}, &destination); err != nil {
-			return "", "", errors.WithMessage(err, "get destination Pool")
-		}
-	*/
+func (r *Reconciler) reconcile(context.Context, Backup) (state, reason string, returnedErr error) {
 	return "Ready", "", nil
 }

--- a/internal/backup/reconciler.go
+++ b/internal/backup/reconciler.go
@@ -20,15 +20,41 @@ func NewReconciler(client client.Client) *Reconciler {
 
 // Reconcile implements [reconcile.Reconciler]
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := log.FromContext(ctx)
-	log.Info("checking request", "request", request)
+	logger := log.FromContext(ctx)
+	logger.Info("checking request", "request", request)
 	var backup Backup
 	if err := r.client.Get(ctx, request.NamespacedName, &backup); err != nil {
 		return reconcile.Result{}, err
 	}
-	backup.Status.State = "Ready"
+	logger.Info("got backup", "backup", backup.Spec)
+
+	state, reason, reconcileErr := r.reconcile(ctx, backup)
+	if reconcileErr != nil {
+		logger.Error(reconcileErr, "reconcile failed")
+		state = "Error"
+		reason = reconcileErr.Error()
+	} else {
+		logger.Info("backup reconciled successfully", "state", state)
+	}
+	backup.Status = &Status{
+		State:  state,
+		Reason: reason,
+	}
 	if err := r.client.Status().Update(ctx, &backup); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
+}
+
+func (r *Reconciler) reconcile(ctx context.Context, backup Backup) (state, reason string, returnedErr error) {
+	/*
+		var source, destination pool.Pool
+		if err := r.client.Get(ctx, client.ObjectKey{Namespace: backup.Namespace, Name: backup.Spec.Source.Name}, &source); err != nil {
+			return "", "", errors.WithMessage(err, "get source Pool")
+		}
+		if err := r.client.Get(ctx, client.ObjectKey{Namespace: backup.Namespace, Name: backup.Spec.Destination.Name}, &destination); err != nil {
+			return "", "", errors.WithMessage(err, "get destination Pool")
+		}
+	*/
+	return "Ready", "", nil
 }

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -1,0 +1,168 @@
+package operator
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"io"
+	"log/slog"
+	"net"
+	"runtime"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/johnstarich/zfs-sync-operator/internal/backup"
+	"github.com/johnstarich/zfs-sync-operator/internal/name"
+	"github.com/johnstarich/zfs-sync-operator/internal/pointer"
+	"github.com/johnstarich/zfs-sync-operator/internal/pool"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	clientconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func Run(ctx context.Context, args []string, out io.Writer) error {
+	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
+	logLevel := flagSet.Int("log-level", 0, "The log level. Defaults to Info. Use -4 for Debug, 4 for Warn, and 8 for Error.")
+	err := flagSet.Parse(args)
+	if err != nil {
+		return err
+	}
+	if len(flagSet.Args()) > 0 {
+		return errors.New(name.Operator + ": this command does not take any arguments")
+	}
+	restConfig, err := clientconfig.GetConfig()
+	if err != nil {
+		return err
+	}
+	const operatorNamespace = name.Operator + "-system"
+	o, err := New(ctx, restConfig, Config{
+		LogHandler: slog.NewJSONHandler(out, &slog.HandlerOptions{Level: slog.Level(*logLevel)}),
+		Namespace:  operatorNamespace,
+	})
+	if err != nil {
+		return err
+	}
+	return o.Wait()
+}
+
+func mustNewScheme() *apiruntime.Scheme {
+	scheme := apiruntime.NewScheme()
+	err := clientsetscheme.AddToScheme(scheme)
+	if err != nil {
+		panic(err)
+	}
+	backup.MustAddToScheme(scheme)
+	pool.MustAddToScheme(scheme)
+	return scheme
+}
+
+// Operator manages the lifecycle of the ZFS offsite backup operator. See the README for more details.
+type Operator struct {
+	manager  manager.Manager
+	startErr chan error
+}
+
+// Config contains configuration to set up an [Operator]
+type Config struct {
+	LogHandler        slog.Handler
+	MetricsPort       string
+	Namespace         string
+	idempotentMetrics bool          // disables safety checks for double metrics registrations
+	maxSessionWait    time.Duration // allows tests to shorten wait times for faster pass/fail results
+}
+
+// New returns a new [Operator]
+func New(ctx context.Context, restConfig *rest.Config, c Config) (*Operator, error) {
+	if c.MetricsPort == "" {
+		c.MetricsPort = "8080"
+	}
+	if c.maxSessionWait == 0 {
+		c.maxSessionWait = 1 * time.Minute
+	}
+	logger := logr.FromSlogHandler(c.LogHandler)
+
+	const reconcilesPerCPU = 2 // Most of the controllers are network-bound, allow a little shared CPU time
+	mgr, err := manager.New(restConfig, manager.Options{
+		LeaderElection:                true,
+		LeaderElectionID:              name.Operator + ".johnstarich.com",
+		LeaderElectionNamespace:       c.Namespace,
+		LeaderElectionReleaseOnCancel: true,
+		Logger:                        logger,
+		BaseContext:                   func() context.Context { return ctx },
+		Scheme:                        mustNewScheme(),
+		Controller: config.Controller{
+			SkipNameValidation:      pointer.Of(c.idempotentMetrics),
+			MaxConcurrentReconciles: runtime.NumCPU() * reconcilesPerCPU,
+		},
+		Metrics: server.Options{
+			BindAddress: net.JoinHostPort("", c.MetricsPort),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	{ // Backup
+		ctrl, err := controller.New("backup", mgr, controller.Options{
+			Reconciler: backup.NewReconciler(mgr.GetClient()),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := ctrl.Watch(source.Kind(
+			mgr.GetCache(),
+			&backup.Backup{},
+			&handler.TypedEnqueueRequestForObject[*backup.Backup]{},
+			predicate.TypedGenerationChangedPredicate[*backup.Backup]{},
+		)); err != nil {
+			return nil, err
+		}
+	}
+	{ // Pool
+		ctrl, err := controller.New("pool", mgr, controller.Options{
+			Reconciler: pool.NewReconciler(mgr.GetClient(), c.maxSessionWait),
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := ctrl.Watch(source.Kind(
+			mgr.GetCache(),
+			&pool.Pool{},
+			&handler.TypedEnqueueRequestForObject[*pool.Pool]{},
+			predicate.TypedGenerationChangedPredicate[*pool.Pool]{},
+		)); err != nil {
+			return nil, err
+		}
+	}
+
+	operator := &Operator{
+		manager:  mgr,
+		startErr: make(chan error),
+	}
+	go func() {
+		operator.startErr <- operator.manager.Start(ctx)
+	}()
+	return operator, nil
+}
+
+func (o *Operator) waitUntilLeader() error {
+	select {
+	case err := <-o.startErr:
+		return err
+	case <-o.manager.Elected():
+		return nil
+	}
+}
+
+// Wait blocks until 'o' has terminated, then returns any error encountered
+func (o *Operator) Wait() error {
+	return <-o.startErr
+}

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -1,3 +1,4 @@
+// Package operator constructs and runs instances of [Operator]
 package operator
 
 import (
@@ -28,6 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+// Run starts an [Operator] with the given runtime context, CLI args, and output stream.
+// Waits until ctx is canceled, then shuts down and returns.
 func Run(ctx context.Context, args []string, out io.Writer) error {
 	flagSet := flag.NewFlagSet("", flag.ContinueOnError)
 	logLevel := flagSet.Int("log-level", 0, "The log level. Defaults to Info. Use -4 for Debug, 4 for Warn, and 8 for Error.")

--- a/internal/operator/test_operator.go
+++ b/internal/operator/test_operator.go
@@ -18,6 +18,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// RunTestMain orchestrates a package's tests to run with an envtestrunner. It controls the full lifecycle of the package.
+//
+// Example:
+//
+//	var TestEnv *envtestrunner.Runner
+//
+//	func TestMain(m *testing.M) {
+//	    operator.RunTestMain(m, &TestEnv)
+//	}
+//
+//	func TestFoo(t *testing.T) {
+//		t.Parallel()
+//		run := operator.RunTest(t, TestEnv)
+//		...
+//	}
 func RunTestMain(m *testing.M, storeTestEnv **envtestrunner.Runner) {
 	flag.Parse()
 	if testing.Short() {
@@ -38,10 +53,12 @@ func RunTestMain(m *testing.M, storeTestEnv **envtestrunner.Runner) {
 	}
 }
 
+// TestRunConfig contains data necessary for running tests. Returned from [RunTest].
 type TestRunConfig struct {
 	Namespace string
 }
 
+// RunTest sets up an [Operator] and a namespace to create resources in. Uses the existing global [envtestrunner.Runner] set up from a [RunTestMain].
 func RunTest(tb testing.TB, testEnv *envtestrunner.Runner) (returnedConfig TestRunConfig) {
 	tb.Helper()
 	ctx, cancel := context.WithCancel(testEnv.Context())

--- a/internal/operator/test_operator.go
+++ b/internal/operator/test_operator.go
@@ -1,7 +1,8 @@
-package main
+package operator
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -13,22 +14,20 @@ import (
 
 	"github.com/johnstarich/zfs-sync-operator/internal/envtestrunner"
 	"github.com/johnstarich/zfs-sync-operator/internal/testlog"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var TestEnv *envtestrunner.Runner //nolint:gochecknoglobals // The test environment is very expensive to set up, so this performance optimization is required for fast test execution.
-
-func TestMain(m *testing.M) {
+func RunTestMain(m *testing.M, storeTestEnv **envtestrunner.Runner) {
 	flag.Parse()
 	if testing.Short() {
 		return
 	}
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
-	TestEnv = envtestrunner.New(ctx, m.Run, mustNewScheme())
-	if err := TestEnv.Run(os.Stdout); err != nil {
+	testEnv := envtestrunner.New(ctx, m.Run, mustNewScheme())
+	*storeTestEnv = testEnv
+	if err := testEnv.Run(os.Stdout); err != nil {
 		exitCode := 1
 		var exitCoder interface{ ExitCode() int }
 		if errors.As(err, &exitCoder) && exitCoder.ExitCode() != 0 {
@@ -43,9 +42,9 @@ type TestRunConfig struct {
 	Namespace string
 }
 
-func RunTest(tb testing.TB) (returnedConfig TestRunConfig) {
+func RunTest(tb testing.TB, testEnv *envtestrunner.Runner) (returnedConfig TestRunConfig) {
 	tb.Helper()
-	ctx, cancel := context.WithCancel(TestEnv.Context())
+	ctx, cancel := context.WithCancel(testEnv.Context())
 	shutdownCtx, shutdownComplete := context.WithCancel(context.Background())
 	tb.Cleanup(func() {
 		cancel()
@@ -62,7 +61,7 @@ func RunTest(tb testing.TB) (returnedConfig TestRunConfig) {
 			GenerateName: namespaceName(tb),
 		},
 	}
-	err := TestEnv.Client().Create(ctx, namespaceObj)
+	err := testEnv.Client().Create(ctx, namespaceObj)
 	if err != nil {
 		tb.Fatal(err)
 	}
@@ -72,7 +71,7 @@ func RunTest(tb testing.TB) (returnedConfig TestRunConfig) {
 	if testing.Verbose() {
 		level = slog.LevelDebug
 	}
-	operator, err := New(ctx, TestEnv.RESTConfig(), Config{
+	operator, err := New(ctx, testEnv.RESTConfig(), Config{
 		LogHandler:        testlog.NewLogHandler(tb, level),
 		MetricsPort:       "0",
 		Namespace:         namespace,

--- a/internal/pointer/value.go
+++ b/internal/pointer/value.go
@@ -1,5 +1,8 @@
+// Package pointer helps deal with creating or dereferencing pointers.
+// Largely this is to test the common functions and enforce patterns.
 package pointer
 
+// Of returns a pointer to value
 func Of[Value any](value Value) *Value {
 	return &value
 }

--- a/internal/pointer/value.go
+++ b/internal/pointer/value.go
@@ -1,0 +1,5 @@
+package pointer
+
+func Of[Value any](value Value) *Value {
+	return &value
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -23,30 +23,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
-const (
-	group      = name.Operator + ".johnstarich.com"
-	apiVersion = "v1alpha1"
-)
-
 // MustAddToScheme adds the Pool scheme to s
 func MustAddToScheme(s *ctrlruntime.Scheme) {
 	schemeBuilder := &scheme.Builder{
 		GroupVersion: schema.GroupVersion{
-			Group:   group,
-			Version: apiVersion,
+			Group:   name.Operator + ".johnstarich.com",
+			Version: "v1alpha1",
 		},
 	}
 	schemeBuilder.Register(&Pool{}, &PoolList{})
 	err := schemeBuilder.AddToScheme(s)
 	if err != nil {
 		panic(err)
-	}
-}
-
-func typeMeta() metav1.TypeMeta {
-	return metav1.TypeMeta{
-		Kind:       "Pool",
-		APIVersion: group + "/" + apiVersion,
 	}
 }
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -11,6 +11,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/johnstarich/zfs-sync-operator/internal/baddeepcopy"
 	"github.com/johnstarich/zfs-sync-operator/internal/name"
+	"github.com/johnstarich/zfs-sync-operator/internal/pointer"
 	"github.com/johnstarich/zfs-sync-operator/internal/wireguard"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/ssh"
@@ -131,7 +132,7 @@ func (p Pool) WithSession(ctx context.Context, client ctrlclient.Client, do func
 		hostKeyCallback = ssh.HostKeyCallback(func(_ string, _ net.Addr, key ssh.PublicKey) error {
 			// Save host key for validation in next reconcile
 			poolWithHostKey := p
-			poolWithHostKey.Spec.SSH.HostKey = toPointer(key.Marshal())
+			poolWithHostKey.Spec.SSH.HostKey = pointer.Of(key.Marshal())
 			err := client.Update(ctx, &poolWithHostKey)
 			resourceVersion = poolWithHostKey.ResourceVersion
 			return err

--- a/internal/pool/reconciler.go
+++ b/internal/pool/reconciler.go
@@ -112,7 +112,3 @@ func stateFromStateField(state string) string {
 		return "Unknown"
 	}
 }
-
-func toPointer[Value any](value Value) *Value {
-	return &value
-}

--- a/internal/pool/reconciler.go
+++ b/internal/pool/reconciler.go
@@ -42,7 +42,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	result := reconcile.Result{}
 	statusUpdate := Pool{
-		TypeMeta: typeMeta(),
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            request.Name,
 			Namespace:       request.Namespace,

--- a/internal/wireguard/wireguard.go
+++ b/internal/wireguard/wireguard.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/netip"
 
+	"github.com/johnstarich/zfs-sync-operator/internal/pointer"
 	"golang.zx2c4.com/wireguard/tun/netstack"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
@@ -33,11 +34,11 @@ type Config struct {
 func Start(ctx context.Context, config Config) (*netstack.Net, error) {
 	var listenPort *int
 	if config.ListenPort != 0 {
-		listenPort = toPointer(config.ListenPort)
+		listenPort = pointer.Of(config.ListenPort)
 	}
 	var presharedKey *wgtypes.Key
 	if len(config.PresharedKey) > 0 {
-		presharedKey = toPointer(wgtypes.Key(config.PresharedKey))
+		presharedKey = pointer.Of(wgtypes.Key(config.PresharedKey))
 	}
 	var address *net.UDPAddr
 	if config.PeerAddress != nil {
@@ -48,7 +49,7 @@ func Start(ctx context.Context, config Config) (*netstack.Net, error) {
 		address = udpAddr
 	}
 	wgConfig := wgtypes.Config{
-		PrivateKey:   toPointer(wgtypes.Key(config.LocalPrivateKey)),
+		PrivateKey:   pointer.Of(wgtypes.Key(config.LocalPrivateKey)),
 		ListenPort:   listenPort,
 		ReplacePeers: true,
 		Peers: []wgtypes.PeerConfig{
@@ -121,10 +122,6 @@ func mustWritef(w io.Writer, format string, args ...any) {
 	if err != nil {
 		panic(err)
 	}
-}
-
-func toPointer[Value any](value Value) *Value {
-	return &value
 }
 
 func valueOrZeroValue[Value any](pointer *Value) Value {

--- a/internal/wireguard/wireguard_test.go
+++ b/internal/wireguard/wireguard_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/johnstarich/zfs-sync-operator/internal/pointer"
 	"github.com/johnstarich/zfs-sync-operator/internal/testlog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -97,7 +98,7 @@ func makeHTTPClient(t *testing.T, addr netip.Addr, presharedKey, privateKey, pee
 		PresharedKey:    presharedKey[:],
 		LocalPrivateKey: privateKey[:],
 		PeerPublicKey:   peerPublicKey[:],
-		PeerAddress:     toPointer(peerAddr.String()),
+		PeerAddress:     pointer.Of(peerAddr.String()),
 	})
 	require.NoError(t, err)
 	return &http.Client{


### PR DESCRIPTION

* Extract operator to its own package, move controller tests to their respective packages. Moving tests should improve coverage accuracy and test caching
* Remove unnecessary type metadata from pool schema
* Remove unnecessary intermediate status update Pool instance
* Prepare func for backup reconcile. This part is a little half-baked right now, but will get updates soon.
* Add docs
