### PR TITLE
Resume interrupted sends

### DIFF
--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -46,9 +46,10 @@ type Spec struct {
 
 // Status holds status information for a [Backup]
 type Status struct {
-	State            State                        `json:"state"`
-	Reason           string                       `json:"reason"`
-	LastSentSnapshot *corev1.LocalObjectReference `json:"lastSentSnapshot,omitempty"`
+	State              State                        `json:"state"`
+	Reason             string                       `json:"reason"`
+	InProgressSnapshot *corev1.LocalObjectReference `json:"inProgressSnapshot,omitempty"`
+	LastSentSnapshot   *corev1.LocalObjectReference `json:"lastSentSnapshot,omitempty"`
 }
 
 // BackupList is a list of [Backup]. Required to perform a Watch.

--- a/internal/backup/reconciler.go
+++ b/internal/backup/reconciler.go
@@ -347,15 +347,15 @@ func (r *Reconciler) sendDatasetSnapshot(ctx context.Context, backup *Backup, so
 		for {
 			status := Status{
 				State: Sending,
-				InProgressSnapshot: &corev1.LocalObjectReference{
-					Name: snapshotName,
-				},
 			}
 			newCount := countWriter.Count()
 			sentValue, sentUnit := datasize.Bytes(newCount).FormatIEC()
 			rate := (newCount - lastCount) / int64(statusUpdateInterval/time.Second)
 			rateValue, rateUnit := datasize.Bytes(rate).FormatIEC()
 			status.Reason = fmt.Sprintf("sending %s: sent %.1f %s (%.0f %s/s)", fullSnapshotName, sentValue, sentUnit, rateValue, rateUnit)
+			if newCount > 0 {
+				status.InProgressSnapshot = &corev1.LocalObjectReference{Name: snapshotName}
+			}
 
 			lastCount = newCount
 			if err := r.patchStatus(ctx, backup.Namespace, backup.Name, status); err != nil {

--- a/internal/backup/reconciler.go
+++ b/internal/backup/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/johnstarich/go/datasize"
@@ -220,7 +221,7 @@ func (r *Reconciler) reconcile(ctx context.Context, backup *Backup) (State, erro
 
 	err = source.WithConnection(ctx, r.client, func(sourceConn *pool.Connection) error {
 		return destination.WithConnection(ctx, r.client, func(destinationConn *pool.Connection) error {
-			return r.sendPoolSnapshot(ctx, backup, destination, sourceConn, destinationConn, sendLastSnapshot)
+			return r.sendPoolSnapshot(ctx, backup, source, destination, sourceConn, destinationConn, sendLastSnapshot)
 		})
 	})
 	if err != nil {
@@ -261,48 +262,83 @@ func (r *Reconciler) matchingBackups(ctx context.Context, poolName, poolNamespac
 	return allBackups, nil
 }
 
-func (r *Reconciler) sendPoolSnapshot(ctx context.Context, backup *Backup, destinationPool pool.Pool, sourceConn, destinationConn *pool.Connection, snapshot *pool.PoolSnapshot) error {
+func (r *Reconciler) sendPoolSnapshot(ctx context.Context, backup *Backup, sourcePool, destinationPool pool.Pool, sourceConn, destinationConn *pool.Connection, snapshot *pool.PoolSnapshot) error {
 	if snapshot.Status == nil || snapshot.Status.DatasetNames == nil {
 		return errors.Errorf("snapshot %q status does not contain snapshotted dataset names to send: %+v", snapshot.Name, snapshot.Status)
 	}
 	for _, datasetName := range *snapshot.Status.DatasetNames {
-		err := r.sendDatasetSnapshot(ctx, backup, destinationPool, sourceConn, destinationConn, datasetName, snapshot.Name)
+		err := r.sendDatasetSnapshot(ctx, backup, sourcePool, destinationPool, sourceConn, destinationConn, datasetName, snapshot.Name)
 		if err != nil {
 			return err
 		}
 	}
+	backup.Status.InProgressSnapshot = nil
 	backup.Status.LastSentSnapshot = &corev1.LocalObjectReference{Name: snapshot.Name}
 	return r.client.Status().Update(ctx, backup)
 }
 
-func (r *Reconciler) sendDatasetSnapshot(ctx context.Context, backup *Backup, destinationPool pool.Pool, sourceConn, destinationConn *pool.Connection, datasetName, snapshotName string) error {
+func (r *Reconciler) sendDatasetSnapshot(ctx context.Context, backup *Backup, sourcePool, destinationPool pool.Pool, sourceConn, destinationConn *pool.Connection, sourceDatasetName, snapshotName string) error {
 	logger := log.FromContext(ctx)
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	sendArgs := []string{
-		"/usr/sbin/zfs", "send",
-		"--raw",       // Always send raw streams. Must be enabled to avoid decrypting and sending data in the clear.
-		"--replicate", // Copies all data contained in the snapshot - properties, snapshots, descendent file systems, and clones are preserved.
+	const datasetSeparator = "/"
+	sourcePrefix := sourcePool.Spec.Name + datasetSeparator
+	if !strings.HasPrefix(sourceDatasetName, sourcePrefix) {
+		return errors.Errorf("unexpected dataset name %q must begin with source pool's name %q", sourceDatasetName, sourcePrefix)
 	}
-	if backup.Status.LastSentSnapshot != nil { // Use incremental send after first send
-		sendArgs = append(sendArgs, "-I", "@"+backup.Status.LastSentSnapshot.Name)
+	destinationDatasetName := destinationPool.Spec.Name + datasetSeparator + strings.TrimPrefix(sourceDatasetName, sourcePrefix)
+
+	sendArgs := []string{"/usr/bin/sudo", "/usr/sbin/zfs", "send"}
+	var receiveResumeToken *string
+	if backup.Status.InProgressSnapshot != nil && backup.Status.InProgressSnapshot.Name == snapshotName {
+		const zfsGetUnsetValue = "-"
+		tokenBytes, err := destinationConn.ExecCombinedOutput(ctx, "/usr/sbin/zfs", "get",
+			"-H",          // Skip table headers
+			"-o", "value", // Only return the token's value
+			"receive_resume_token", // Only return the token
+			destinationDatasetName,
+		)
+		if err != nil {
+			logger.Error(err, "Failed to retrieve receive_resume_token, sending from scratch...")
+		} else if token := string(tokenBytes); token != zfsGetUnsetValue {
+			receiveResumeToken = &token
+		} else {
+			logger.Info("No receive_resume_token available for in progress send, sending from scratch...")
+		}
 	}
-	fullSnapshotName := fmt.Sprintf("%s@%s", datasetName, snapshotName)
-	sendArgs = append(sendArgs, fullSnapshotName)
+
+	fullSnapshotName := fmt.Sprintf("%s@%s", sourceDatasetName, snapshotName)
+	if receiveResumeToken == nil { // If we're not resuming an interrupted send, create a normal send stream with all options
+		sendArgs = append(sendArgs,
+			"--raw",       // Always send raw streams. Must be enabled to avoid decrypting and sending data in the clear.
+			"--replicate", // Copies all data contained in the snapshot - properties, snapshots, descendent file systems, and clones are preserved.
+		)
+		if backup.Status.LastSentSnapshot != nil { // Use incremental send after first send
+			sendArgs = append(sendArgs, "-I", "@"+backup.Status.LastSentSnapshot.Name)
+		}
+		sendArgs = append(sendArgs, fullSnapshotName)
+	} else {
+		sendArgs = append(sendArgs, "-t", *receiveResumeToken) // Attempt to resume an interrupted send via a "receive_resume_token"
+	}
+
+	receiveArgs := []string{
+		"/usr/bin/sudo", "/usr/sbin/zfs", "receive",
+		"-d", // Preserve hierarchy when using recursive replicated streams
+		"-s", // Enable send to resume later if interrupted
+		destinationPool.Spec.Name,
+	}
+	logger.Info("Syncing", "sendCommand", sendArgs, "receiveCommand", receiveArgs)
 
 	const maxExpectedErrors = 2
 	errs := make(chan error, maxExpectedErrors)
 	pipeReader, pipeWriter := io.Pipe()
 	countWriter := iocount.NewWriter(pipeWriter)
 	go func() {
-		errs <- sourceConn.ExecWriteStdout(ctx, countWriter, "/usr/bin/sudo", sendArgs...)
+		errs <- sourceConn.ExecWriteStdout(ctx, countWriter, sendArgs[0], sendArgs[1:]...)
 	}()
 	go func() {
-		errs <- destinationConn.ExecReadStdin(ctx, pipeReader, "/usr/bin/sudo", "/usr/sbin/zfs", "receive",
-			"-d", // Preserve hierarchy when using recursive replicated streams
-			destinationPool.Spec.Name,
-		)
+		errs <- destinationConn.ExecReadStdin(ctx, pipeReader, receiveArgs[0], receiveArgs[1:]...)
 	}()
 	go func() {
 		const statusUpdateInterval = 30 * time.Second
@@ -311,6 +347,9 @@ func (r *Reconciler) sendDatasetSnapshot(ctx context.Context, backup *Backup, de
 		for {
 			status := Status{
 				State: Sending,
+				InProgressSnapshot: &corev1.LocalObjectReference{
+					Name: snapshotName,
+				},
 			}
 			newCount := countWriter.Count()
 			sentValue, sentUnit := datasize.Bytes(newCount).FormatIEC()

--- a/internal/backup/reconciler_test.go
+++ b/internal/backup/reconciler_test.go
@@ -1,6 +1,7 @@
 package backup_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/netip"
@@ -271,7 +272,7 @@ func TestBackupSendAndReceive(t *testing.T) {
 	receiveCalled := false
 	destination := makePool(t, "destination", run, TestPoolOptions{
 		SSHExecResults: map[string]*ssh.TestExecResult{
-			`/usr/bin/sudo /usr/sbin/zfs receive -d destination`: {ExpectStdin: []byte(`some data`), Called: &receiveCalled},
+			`/usr/bin/sudo /usr/sbin/zfs receive -d -s destination`: {ExpectStdin: []byte(`some data`), Called: &receiveCalled},
 		},
 	})
 
@@ -337,7 +338,7 @@ func TestBackupSendAndReceiveIncremental(t *testing.T) {
 	receiveCalled := false
 	destination := makePool(t, "destination", run, TestPoolOptions{
 		SSHExecResults: map[string]*ssh.TestExecResult{
-			`/usr/bin/sudo /usr/sbin/zfs receive -d destination`: {ExpectStdin: []byte(`some data`), Called: &receiveCalled},
+			`/usr/bin/sudo /usr/sbin/zfs receive -d -s destination`: {ExpectStdin: []byte(`some data`), Called: &receiveCalled},
 		},
 	})
 
@@ -396,6 +397,94 @@ func TestBackupSendAndReceiveIncremental(t *testing.T) {
 		}, backup.Status)
 	}, maxWait, tick)
 	assert.True(t, receiveCalled, "ZFS receive should be called for incrementally sent snapshots")
+}
+
+func TestBackupResumeSendAndReceive(t *testing.T) {
+	t.Parallel()
+	run := operator.RunTest(t, TestEnv)
+	// Create pools and wait for scheduled snapshot
+	sourceSSHResults := make(map[string]*ssh.TestExecResult)
+	const (
+		someSourceDataset      = "source/some-dataset"
+		someDestinationDataset = "destination/some-dataset"
+	)
+	source := makePool(t, "source", run, TestPoolOptions{
+		SSHExecResults: sourceSSHResults,
+		SSHExecPrefixResults: map[string]*ssh.TestExecResult{
+			`/usr/bin/sudo /usr/sbin/zfs snapshot -r ` + someSourceDataset: {ExitCode: 0},
+		},
+	})
+	source.Spec.Snapshots = &zfspool.SnapshotsSpec{
+		Intervals: []zfspool.SnapshotIntervalSpec{
+			{Name: "hourly", Interval: metav1.Duration{Duration: 1 * time.Hour}, HistoryLimit: 1},
+		},
+		Template: zfspool.SnapshotSpecTemplate{
+			Datasets: []zfspool.DatasetSelector{{Name: someSourceDataset, Recursive: &zfspool.RecursiveDatasetSpec{}}},
+		},
+	}
+	require.NoError(t, TestEnv.Client().Update(TestEnv.Context(), &source))
+	var sourceSnapshot zfspool.PoolSnapshot
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		var sourceSnapshots zfspool.PoolSnapshotList
+		assert.NoError(collect, TestEnv.Client().List(TestEnv.Context(), &sourceSnapshots, &client.ListOptions{Namespace: run.Namespace}))
+		if assert.Len(collect, sourceSnapshots.Items, 1) {
+			sourceSnapshot = *sourceSnapshots.Items[0]
+			if assert.NotNil(collect, sourceSnapshot.Status) {
+				assert.Equalf(collect, zfspool.SnapshotCompleted, sourceSnapshot.Status.State, "Status: %v", sourceSnapshot.Status)
+			}
+		}
+	}, maxWait, tick)
+	const someReceiveResumeToken = "some-receive-resume-token"
+	sourceSSHResults[fmt.Sprintf(`/usr/bin/sudo /usr/sbin/zfs send -t %s`, someReceiveResumeToken)] = &ssh.TestExecResult{Stdout: []byte(`some data`)}
+	timeoutCtx, cancel := context.WithTimeout(TestEnv.Context(), 1*time.Second)
+	t.Cleanup(cancel)
+	sourceSSHResults[fmt.Sprintf(`/usr/bin/sudo /usr/sbin/zfs send --raw --replicate %s\@%s`, someSourceDataset, sourceSnapshot.Name)] = &ssh.TestExecResult{Stdout: []byte(`some data`) /* send the same data to avoid tripping the stdin assertion on receive */, ExitCode: 1, WaitContext: timeoutCtx}
+
+	// Create backup and patch status as "in progress"
+	const someBackup = "mybackup"
+	backup := zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+		Spec: zfsbackup.Spec{
+			Source: corev1.LocalObjectReference{Name: source.Name},
+		},
+	}
+	require.NoError(t, TestEnv.Client().Create(TestEnv.Context(), &backup))
+	require.NoError(t, TestEnv.Client().Status().Patch(TestEnv.Context(), &zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+		Status: &zfsbackup.Status{
+			InProgressSnapshot: &corev1.LocalObjectReference{
+				Name: sourceSnapshot.Name,
+			},
+		},
+	}, client.Merge))
+
+	// then set up destination pool
+	receiveCalled := false
+	destination := makePool(t, "destination", run, TestPoolOptions{
+		SSHExecResults: map[string]*ssh.TestExecResult{
+			fmt.Sprintf(`/usr/sbin/zfs get -H -o value receive\_resume\_token %s`, someDestinationDataset): {Stdout: []byte(someReceiveResumeToken)},
+			`/usr/bin/sudo /usr/sbin/zfs receive -d -s destination`:                                        {ExpectStdin: []byte(`some data`), Called: &receiveCalled},
+		},
+	})
+	require.NoError(t, TestEnv.Client().Patch(TestEnv.Context(), &zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+		Spec: zfsbackup.Spec{
+			Destination: corev1.LocalObjectReference{Name: destination.Name},
+		},
+	}, client.Merge))
+
+	// and wait for sync
+	backup = zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+	}
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.NoError(collect, TestEnv.Client().Get(TestEnv.Context(), client.ObjectKeyFromObject(&backup), &backup))
+		assert.Equal(collect, &zfsbackup.Status{
+			State:            zfsbackup.Ready,
+			LastSentSnapshot: &corev1.LocalObjectReference{Name: sourceSnapshot.Name},
+		}, backup.Status)
+	}, maxWait, tick)
+	assert.True(t, receiveCalled, "ZFS receive should be called for resumed send snapshots")
 }
 
 type zeroReader struct{}

--- a/internal/backup/reconciler_test.go
+++ b/internal/backup/reconciler_test.go
@@ -1,7 +1,6 @@
 package backup_test
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/netip"
@@ -436,9 +435,6 @@ func TestBackupResumeSendAndReceive(t *testing.T) {
 	}, maxWait, tick)
 	const someReceiveResumeToken = "some-receive-resume-token"
 	sourceSSHResults[fmt.Sprintf(`/usr/bin/sudo /usr/sbin/zfs send -t %s`, someReceiveResumeToken)] = &ssh.TestExecResult{Stdout: []byte(`some data`)}
-	timeoutCtx, cancel := context.WithTimeout(TestEnv.Context(), 1*time.Second)
-	t.Cleanup(cancel)
-	sourceSSHResults[fmt.Sprintf(`/usr/bin/sudo /usr/sbin/zfs send --raw --replicate %s\@%s`, someSourceDataset, sourceSnapshot.Name)] = &ssh.TestExecResult{Stdout: []byte(`some data`) /* send the same data to avoid tripping the stdin assertion on receive */, ExitCode: 1, WaitContext: timeoutCtx}
 
 	// Create backup and patch status as "in progress"
 	const someBackup = "mybackup"

--- a/internal/config/crd/backup.yaml
+++ b/internal/config/crd/backup.yaml
@@ -37,6 +37,11 @@ spec:
                 type: string
               reason:
                 type: string
+              inProgressSnapshot:
+                type: object
+                properties:
+                  name:
+                    type: string
               lastSentSnapshot:
                 type: object
                 properties:


### PR DESCRIPTION

Resume interrupted sends. This helps a ton on the initial sends, especially slow or unstable links.
