### PR TITLE
Add missing RBAC for custom resource finalizers

### DIFF
--- a/internal/config/templates/clusterrole.yaml
+++ b/internal/config/templates/clusterrole.yaml
@@ -7,10 +7,13 @@ rules:
   - zfs-sync-operator.johnstarich.com
   resources:
   - backups
+  - backups/finalizers
   - backups/status
   - pools
+  - pools/finalizers
   - pools/status
   - poolsnapshots
+  - poolsnapshots/finalizers
   - poolsnapshots/status
   verbs:
   - create


### PR DESCRIPTION

Add missing RBAC for custom resource finalizers

Fixes this error:
```
failed reconciling interval hourly: poolsnapshots.zfs-sync-operator.johnstarich.com "hourly-de400043-e025-4938-925c-f45ec828f592" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
```
