### PR TITLE
Add initial integration with Prometheus Operator

### DIFF
--- a/internal/config/templates/deployment.yaml
+++ b/internal/config/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: zfs-sync-operator
           image: "ghcr.io/johnstarich/zfs-sync-operator:{{ .Chart.Version }}"
           ports:
-            - name: metrics
+            - name: http-metrics
               containerPort: 8080
               protocol: TCP
             - name: http

--- a/internal/config/templates/podmonitor.yaml
+++ b/internal/config/templates/podmonitor.yaml
@@ -1,0 +1,14 @@
+#{{ if .Values.prometheusMonitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: zfs-sync-operator
+  labels:
+    app: zfs-sync-operator
+spec:
+  selector:
+    matchLabels:
+      app: zfs-sync-operator
+  podMetricsEndpoints:
+  - port: http-metrics
+#{{ end }}

--- a/internal/config/templates/prometheusrule.yaml
+++ b/internal/config/templates/prometheusrule.yaml
@@ -1,0 +1,20 @@
+#{{ if .Values.prometheusMonitoring.enabled }}
+# NOTE: Alert does not appear in the OpenShift Console notification bell currently: https://issues.redhat.com/browse/OBSDA-1039
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: zfs-sync-operator
+spec:
+  groups:
+    - name: zfs-sync-operator.rules
+      rules: []
+      #  - alert: ZFSPoolNotHealthy
+      #    expr: vector(1)
+      #    for: 5m
+      #    labels:
+      #      severity: warning
+      #      namespace: TODO
+      #    annotations:
+      #      summary: TODO
+      #      description: TODO
+#{{ end }}

--- a/internal/config/values.yaml
+++ b/internal/config/values.yaml
@@ -11,3 +11,7 @@ resources:
 # More information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 #imagePullSecrets:
 #  - name: mysecret
+
+# Enable PrometheusRule resources to be created. Automatically alerts on problems requiring intervention.
+prometheusMonitoring:
+  enabled: true

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/http"
 	"runtime"
 	"time"
 
@@ -134,7 +135,14 @@ func New(ctx context.Context, restConfig *rest.Config, c Config) (*Operator, err
 	if err != nil {
 		return nil, err
 	}
-	if err := mgr.AddReadyzCheck("ping", healthz.Ping); err != nil {
+	if err := mgr.AddReadyzCheck("leader", func(*http.Request) error {
+		select {
+		case <-mgr.Elected():
+			return nil
+		default:
+			return errors.New("not the leader")
+		}
+	}); err != nil {
 		return nil, err
 	}
 	if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {


### PR DESCRIPTION

Configures some scaffolding to work with Prometheus Operator, including
a scrape and alert config.
Marks only the leader Pod as Ready to simplify metrics scraping.

Part of upcoming work on https://github.com/JohnStarich/zfs-sync-operator/issues/10, https://github.com/JohnStarich/zfs-sync-operator/issues/11, https://github.com/JohnStarich/zfs-sync-operator/issues/20
