### PR TITLE
Record metric and alert on unhealthy backups and pools

### DIFF
--- a/internal/backup/reconciler.go
+++ b/internal/backup/reconciler.go
@@ -44,6 +44,7 @@ const (
 	destinationProperty = ".spec.destination.name"
 )
 
+// SendStatusUpdateInterval is the time between status updates during a send
 const SendStatusUpdateInterval = 30 * time.Second
 
 // RegisterReconciler registers a Backup reconciler with manager

--- a/internal/backup/reconciler_test.go
+++ b/internal/backup/reconciler_test.go
@@ -1,6 +1,7 @@
 package backup_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/netip"
@@ -653,4 +654,94 @@ func watchBackupStatusUpdates(tb testing.TB, namespace string, handleStatus func
 			}
 		}
 	}
+}
+
+func TestBackupSendingStateAndMetrics(t *testing.T) {
+	t.Parallel()
+	run := operator.RunTest(t, TestEnv)
+	sourceSSHResults := make(map[string]*ssh.TestExecResult)
+	const someDataset = "source/some-dataset"
+	source := makePool(t, "source", run, TestPoolOptions{
+		SSHExecResults: sourceSSHResults,
+		SSHExecPrefixResults: map[string]*ssh.TestExecResult{
+			`/usr/bin/sudo /usr/sbin/zfs snapshot -r ` + someDataset: {ExitCode: 0},
+		},
+	})
+	source.Spec.Snapshots = &zfspool.SnapshotsSpec{
+		Intervals: []zfspool.SnapshotIntervalSpec{
+			{Name: "hourly", Interval: metav1.Duration{Duration: 1 * time.Hour}, HistoryLimit: 1},
+		},
+		Template: zfspool.SnapshotSpecTemplate{
+			Datasets: []zfspool.DatasetSelector{
+				{Name: someDataset, Recursive: &zfspool.RecursiveDatasetSpec{}},
+			},
+		},
+	}
+	require.NoError(t, TestEnv.Client().Update(TestEnv.Context(), &source))
+	var sourceSnapshot zfspool.PoolSnapshot
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		var sourceSnapshots zfspool.PoolSnapshotList
+		assert.NoError(collect, TestEnv.Client().List(TestEnv.Context(), &sourceSnapshots, &client.ListOptions{Namespace: run.Namespace}))
+		if assert.Len(collect, sourceSnapshots.Items, 1) {
+			sourceSnapshot = *sourceSnapshots.Items[0]
+			if assert.NotNil(collect, sourceSnapshot.Status) {
+				assert.Equalf(collect, zfspool.SnapshotCompleted, sourceSnapshot.Status.State, "Status: %v", sourceSnapshot.Status)
+			}
+		}
+	}, maxWait, tick)
+	const sendData = `some data`
+	sourceSSHResults[fmt.Sprintf(`/usr/bin/sudo /usr/sbin/zfs send --raw --replicate %s\@%s`, someDataset, sourceSnapshot.Name)] = &ssh.TestExecResult{Stdout: []byte(sendData)}
+
+	receiveWait, receiveResume := context.WithCancel(TestEnv.Context())
+	t.Cleanup(receiveResume)
+	destination := makePool(t, "destination", run, TestPoolOptions{
+		SSHExecResults: map[string]*ssh.TestExecResult{
+			`/usr/bin/sudo /usr/sbin/zfs receive -d -s destination`: {ExpectStdin: []byte(sendData), WaitContext: receiveWait},
+		},
+	})
+
+	const someBackup = "mybackup"
+	backup := zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+		Spec: zfsbackup.Spec{
+			Source:      corev1.LocalObjectReference{Name: source.Name},
+			Destination: corev1.LocalObjectReference{Name: destination.Name},
+		},
+	}
+	require.NoError(t, TestEnv.Client().Create(TestEnv.Context(), &backup))
+
+	backup = zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+	}
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.NoError(collect, TestEnv.Client().Get(TestEnv.Context(), client.ObjectKeyFromObject(&backup), &backup))
+		assert.Equal(collect, &zfsbackup.Status{
+			State:              zfsbackup.Sending,
+			Reason:             fmt.Sprintf("sending %s@%s: sent %.1f B (0 B/s)", someDataset, sourceSnapshot.Name, float64(len(sendData))),
+			InProgressSnapshot: &corev1.LocalObjectReference{Name: sourceSnapshot.Name},
+		}, backup.Status)
+	}, zfsbackup.SendStatusUpdateInterval*2, zfsbackup.SendStatusUpdateInterval/4)
+	assert.NoError(t, testutil.GatherAndCompare(run.Metrics, strings.NewReader(fmt.Sprintf(`
+# HELP zfs_sync_backup_in_progress_snapshot_deadline The deadline for the current in progress snapshot. Deadline is represented as the number of seconds since January 1, 1970 UTC - same as the Prometheus time() function.
+# TYPE zfs_sync_backup_in_progress_snapshot_deadline gauge
+zfs_sync_backup_in_progress_snapshot_deadline{name=%q,namespace=%q} %d
+`, someBackup, run.Namespace, run.Clock.Now().Add(2*time.Hour).Unix())), "zfs_sync_backup_in_progress_snapshot_deadline"))
+	receiveResume()
+
+	backup = zfsbackup.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: someBackup, Namespace: run.Namespace},
+	}
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		assert.NoError(collect, TestEnv.Client().Get(TestEnv.Context(), client.ObjectKeyFromObject(&backup), &backup))
+		assert.Equal(collect, &zfsbackup.Status{
+			State:            zfsbackup.Ready,
+			LastSentSnapshot: &corev1.LocalObjectReference{Name: sourceSnapshot.Name},
+		}, backup.Status)
+	}, maxWait, tick)
+
+	assert.NoError(t, testutil.GatherAndCompare(run.Metrics, strings.NewReader(fmt.Sprintf(`
+# HELP zfs_sync_backup_in_progress_snapshot_deadline The deadline for the current in progress snapshot. Deadline is represented as the number of seconds since January 1, 1970 UTC - same as the Prometheus time() function.
+# TYPE zfs_sync_backup_in_progress_snapshot_deadline gauge
+zfs_sync_backup_in_progress_snapshot_deadline{name=%q,namespace=%q} 0
+`, someBackup, run.Namespace)), "zfs_sync_backup_in_progress_snapshot_deadline"))
 }

--- a/internal/backup/state.go
+++ b/internal/backup/state.go
@@ -1,12 +1,69 @@
 package backup
 
+import (
+	"fmt"
+	"iter"
+
+	"github.com/pkg/errors"
+)
+
 // State represents all backup lifecycle states
-type State string
+type State int
 
 // Backup lifecycle states
 const (
-	Error    = State("Error")    // The operator failed to send recent snapshots
-	NotReady = State("NotReady") // One or both Pools are not ready to send/receive snapshots
-	Ready    = State("Ready")    // Backup is ready to send/receive snapshots
-	Sending  = State("Sending")  // Backup is sending a snapshot
+	UnexpectedError State = iota // The operator failed unexpectedly
+
+	Error    // The operator failed to send recent snapshots
+	NotReady // One or both Pools are not ready to send/receive snapshots
+	Ready    // Backup is ready to send/receive snapshots
+	Sending  // Backup is sending a snapshot
+
+	maxState // marker to select all possible states
 )
+
+// AllStates returns an iterator over all valid values of [State]
+func AllStates() iter.Seq[State] {
+	return func(yield func(state State) bool) {
+		for state := range maxState {
+			if !yield(state) {
+				return
+			}
+		}
+	}
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler]
+func (s *State) UnmarshalText(b []byte) error {
+	str := string(b)
+	for state := range AllStates() {
+		if str == state.String() {
+			*s = state
+			return nil
+		}
+	}
+	return errors.Errorf("invalid backup state name: %s", b)
+}
+
+// MarshalText implements [encoding.TextMarshaler]
+func (s State) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s State) String() string {
+	switch s {
+	case Error:
+		return "Error"
+	case NotReady:
+		return "NotReady"
+	case Ready:
+		return "Ready"
+	case Sending:
+		return "Sending"
+	case UnexpectedError:
+		return "UnexpectedError"
+	case maxState:
+	default:
+	}
+	panic(fmt.Sprintf("unrecognized backup state: %d", s))
+}

--- a/internal/config/alert.rules.yaml
+++ b/internal/config/alert.rules.yaml
@@ -7,7 +7,6 @@ spec:
   groups:
     - name: zfs-sync-operator.rules
       rules:
-        # TODO double check this periodically updates \/
         - alert: ZFSPoolUnhealthy
           expr: zfs_sync_pool_state{state!~"Online"} > 0
           for: 5m
@@ -29,8 +28,8 @@ spec:
             description: |
               ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
         - alert: ZFSBackupNotProgressing
-          expr: increase(zfs_sync_backup_sent_bytes[1d]) == 0
-          for: 5m
+          expr: zfs_sync_backup_in_progress_snapshot_deadline != 0 && increase(zfs_sync_backup_sent_bytes[1h]) == 0
+          for: 1h
           labels:
             severity: critical
           annotations:
@@ -38,15 +37,16 @@ spec:
               ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing
             description: |
               ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing.
-              Snapshots have not been sent for > 1 day
-        - alert: ZFSBackupNotProgressing
-          expr: increase(zfs_sync_backup_sent_snapshots[1d]) == 0
-          for: 5m
+              Data transfer rate has been zero for more than 1 hour.
+        - alert: ZFSBackupIsBehindSchedule
+          expr: zfs_sync_backup_in_progress_snapshot_deadline != 0 && zfs_sync_backup_in_progress_snapshot_deadline < time()
+          for: 15m
           labels:
             severity: critical
           annotations:
             summary: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule
             description: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing.
-              Snapshots have not been sent for > 1 day
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule
+              The current snapshot send should have completed sending by now. The deadline {{ }} was {{ }} ago.
+              Check for a slow or unstable network connection to both source and destination pools.

--- a/internal/config/alert.rules.yaml
+++ b/internal/config/alert.rules.yaml
@@ -28,7 +28,7 @@ spec:
             description: |
               ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
         - alert: ZFSBackupNotProgressing
-          expr: zfs_sync_backup_in_progress_snapshot_deadline != 0 && increase(zfs_sync_backup_sent_bytes[1h]) == 0
+          expr: increase(zfs_sync_backup_sent_bytes[1h]) == 0 and zfs_sync_backup_in_progress_snapshot_deadline != 0
           for: 1h
           labels:
             severity: critical
@@ -39,14 +39,14 @@ spec:
               ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing.
               Data transfer rate has been zero for more than 1 hour.
         - alert: ZFSBackupIsBehindSchedule
-          expr: zfs_sync_backup_in_progress_snapshot_deadline != 0 && zfs_sync_backup_in_progress_snapshot_deadline < time()
+          expr: time() - zfs_sync_backup_in_progress_snapshot_deadline > 0 and zfs_sync_backup_in_progress_snapshot_deadline != 0
           for: 15m
           labels:
             severity: critical
           annotations:
             summary: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule ({{ $value | humanizeDuration }})
             description: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule
-              The current snapshot send should have completed sending by now. The deadline {{ }} was {{ }} ago.
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule.
+              The current snapshot send should have completed sending by now. The deadline was {{ $value | humanizeDuration }} ago.
               Check for a slow or unstable network connection to both source and destination pools.

--- a/internal/config/alert.rules.yaml
+++ b/internal/config/alert.rules.yaml
@@ -1,0 +1,52 @@
+# NOTE: Alert does not appear in the OpenShift Console notification bell currently: https://issues.redhat.com/browse/OBSDA-1039
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: zfs-sync-operator
+spec:
+  groups:
+    - name: zfs-sync-operator.rules
+      rules:
+        # TODO double check this periodically updates \/
+        - alert: ZFSPoolUnhealthy
+          expr: zfs_sync_pool_state{state!~"Online"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: |
+              ZFS Pool {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+            description: |
+              ZFS Pool {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+        - alert: ZFSBackupUnhealthy
+          expr: zfs_sync_backup_state{state!~"Ready|Sending"} > 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: |
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+            description: |
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+        - alert: ZFSBackupNotProgressing
+          expr: increase(zfs_sync_backup_sent_bytes[1d]) == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: |
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing
+            description: |
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing.
+              Snapshots have not been sent for > 1 day
+        - alert: ZFSBackupNotProgressing
+          expr: increase(zfs_sync_backup_sent_snapshots[1d]) == 0
+          for: 5m
+          labels:
+            severity: critical
+          annotations:
+            summary: |
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing
+            description: |
+              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing.
+              Snapshots have not been sent for > 1 day

--- a/internal/config/templates/podmonitor.yaml
+++ b/internal/config/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-#{{ if .Values.prometheusMonitoring.enabled }}
+{{- if .Values.prometheusMonitoring.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -11,4 +11,4 @@ spec:
       app: zfs-sync-operator
   podMetricsEndpoints:
   - port: http-metrics
-#{{ end }}
+{{- end }}

--- a/internal/config/templates/prometheusrule.yaml
+++ b/internal/config/templates/prometheusrule.yaml
@@ -1,20 +1,3 @@
-#{{ if .Values.prometheusMonitoring.enabled }}
-# NOTE: Alert does not appear in the OpenShift Console notification bell currently: https://issues.redhat.com/browse/OBSDA-1039
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  name: zfs-sync-operator
-spec:
-  groups:
-    - name: zfs-sync-operator.rules
-      rules: []
-      #  - alert: ZFSPoolNotHealthy
-      #    expr: vector(1)
-      #    for: 5m
-      #    labels:
-      #      severity: warning
-      #      namespace: TODO
-      #    annotations:
-      #      summary: TODO
-      #      description: TODO
-#{{ end }}
+{{- if .Values.prometheusMonitoring.enabled }}
+{{ .Files.Get "alert.rules.yaml" }}
+{{- end }}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,26 @@
+// Package metrics helps register metrics, annotate them with common labels, and assist in assigning them values
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Common metric labels
+const (
+	NamespaceLabel = "namespace"
+	NameLabel      = "name"
+	StateLabel     = "state"
+)
+
+// MustRegister ensures collector is registered to regitry and returns the collector.
+// Primarily used for inline registration and assignment.
+func MustRegister[Collector prometheus.Collector](registry prometheus.Registerer, collector Collector) Collector {
+	registry.MustRegister(collector)
+	return collector
+}
+
+// CountTrue returns 1 if b is true, 0 otherwise
+func CountTrue(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/name/name.go
+++ b/internal/name/name.go
@@ -11,4 +11,7 @@ const (
 	// DomainPrefix is the label prefix to use for an operator property.
 	// For example: DomainPrefix + "myproperty" == "mydomain.io/myproperty"
 	DomainPrefix = Domain + "/"
+
+	// Metrics is the Prometheus namespace for this operator
+	Metrics = "zfs_sync"
 )

--- a/internal/pool/reconciler.go
+++ b/internal/pool/reconciler.go
@@ -190,6 +190,8 @@ func (r *Reconciler) reconcileWithConnection(ctx context.Context, pool *Pool, co
 			}
 		}
 		logger.Info("Requeuing to handle next interval", "requeueAfter", requeueAfter)
+	} else {
+		requeueAfter = 2 * time.Hour // For pools without snapshot schedules, check in on their health infrequently.
 	}
 	return requeueAfter, nil
 }

--- a/internal/pool/snapshot_reconciler.go
+++ b/internal/pool/snapshot_reconciler.go
@@ -148,7 +148,7 @@ func (r *SnapshotReconciler) reconcile(ctx context.Context, snapshot *PoolSnapsh
 		return &SnapshotStatus{State: SnapshotError, Reason: "pool is not ready"}, 0, nil
 	}
 	if pool.Status.State != Online {
-		message := string(pool.Status.State)
+		message := pool.Status.State.String()
 		if pool.Status.Reason != "" {
 			message = fmt.Sprintf("%s: %s", pool.Status.State, pool.Status.Reason)
 		}

--- a/internal/pool/state.go
+++ b/internal/pool/state.go
@@ -1,28 +1,48 @@
 package pool
 
-import "strings"
+import (
+	"fmt"
+	"iter"
+	"strings"
+
+	"github.com/pkg/errors"
+)
 
 // State represents all pool lifecycle states
-type State string
+type State int
 
 // Pool lifecycle states
 const (
-	Degraded = State("Degraded") // ZFS reported a pool state of DEGRADED
-	Error    = State("Error")    // The operator failed to determine pool state
-	Faulted  = State("Faulted")  // ZFS reported a pool state of FAULTED
-	NotFound = State("NotFound") // ZFS could not a pool with the configured name
-	Online   = State("Online")   // ZFS reported a pool state of ONLINE
-	Unknown  = State("Unknown")  // ZFS reported an unexpected pool state
+	Error State = iota // The operator failed to determine pool state
+
+	Degraded // ZFS reported a pool state of DEGRADED
+	Faulted  // ZFS reported a pool state of FAULTED
+	NotFound // ZFS could not a pool with the configured name
+	Online   // ZFS reported a pool state of ONLINE
+	Unknown  // ZFS reported an unexpected pool state
+
+	maxState // marker to select all possible states
 )
+
+// AllStates returns an iterator over all valid values of [State]
+func AllStates() iter.Seq[State] {
+	return func(yield func(state State) bool) {
+		for state := range maxState {
+			if !yield(state) {
+				return
+			}
+		}
+	}
+}
 
 func stateFromStateField(stateField string) State {
 	// A pool's health status is described by one of three states: online, degraded, or faulted.
 	// - https://openzfs.github.io/openzfs-docs/man/v0.8/8/zpool.8.html#Device_Failure_and_Recovery
-	state := toState(stateField)
+	state := toState(normalizeStateToPossibleEnumName(stateField))
 	switch state {
 	case Online, Degraded, Faulted:
 		return state
-	case Error, NotFound, Unknown:
+	case Error, NotFound, Unknown, maxState:
 		// Not real zpool states
 		return Unknown
 	default:
@@ -30,9 +50,55 @@ func stateFromStateField(stateField string) State {
 	}
 }
 
-func toState(state string) State {
-	if len(state) <= 1 {
-		return State(strings.ToUpper(state))
+func toState(possibleStateName string) State {
+	for s := range AllStates() {
+		if possibleStateName == s.String() {
+			return s
+		}
 	}
-	return State(strings.ToUpper(state[0:1]) + strings.ToLower(state[1:]))
+	return Unknown
+}
+
+func normalizeStateToPossibleEnumName(state string) string {
+	if len(state) <= 1 {
+		return strings.ToUpper(state)
+	}
+	return strings.ToUpper(state[0:1]) + strings.ToLower(state[1:])
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler]
+func (s *State) UnmarshalText(b []byte) error {
+	str := string(b)
+	for state := range AllStates() {
+		if str == state.String() {
+			*s = state
+			return nil
+		}
+	}
+	return errors.Errorf("invalid pool state name: %s", b)
+}
+
+// MarshalText implements [encoding.TextMarshaler]
+func (s State) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+func (s State) String() string {
+	switch s {
+	case Degraded:
+		return "Degraded"
+	case Error:
+		return "Error"
+	case Faulted:
+		return "Faulted"
+	case NotFound:
+		return "NotFound"
+	case Online:
+		return "Online"
+	case Unknown:
+		return "Unknown"
+	case maxState:
+	default:
+	}
+	panic(fmt.Sprintf("unrecognized pool state: %d", s))
 }


### PR DESCRIPTION
* Record metric and alert on unhealthy backups and pools
* Use enum for backup.State and pool.State to set metric on each state
* Include raw alert rules yaml to avoid helm+prometheus template errors, add backup alert
* Remove comments in podmonitor, not needed for troubleshooting
* Add metrics and alerts to track backed up snapshots, bytes sent, and if we've passed the schedule's snapshot deadline

Closes https://github.com/JohnStarich/zfs-sync-operator/issues/10
Closes https://github.com/JohnStarich/zfs-sync-operator/issues/11
