### PR TITLE
Fix alert label names to avoid conflicts with built-in namespace labels

### DIFF
--- a/internal/backup/reconciler_test.go
+++ b/internal/backup/reconciler_test.go
@@ -121,7 +121,7 @@ func TestBackupReady(t *testing.T) {
 # TYPE zfs_sync_backup_state gauge
 `
 			for state := range zfsbackup.AllStates() {
-				expectedMetrics += fmt.Sprintf("zfs_sync_backup_state{name=%q,namespace=%q,state=%q} %f\n",
+				expectedMetrics += fmt.Sprintf("zfs_sync_backup_state{resource_name=%q,resource_namespace=%q,state=%q} %f\n",
 					someBackupName,
 					run.Namespace,
 					state.String(),
@@ -328,7 +328,7 @@ func TestBackupSendAndReceive(t *testing.T) {
 			expectedMetrics := fmt.Sprintf(`
 # HELP zfs_sync_backup_sent_snapshots The number of successfully sent snapshots
 # TYPE zfs_sync_backup_sent_snapshots counter
-zfs_sync_backup_sent_snapshots{name=%q,namespace=%q} %d
+zfs_sync_backup_sent_snapshots{resource_name=%q,resource_namespace=%q} %d
 `, someBackup, run.Namespace, sentSnapshots)
 			compareErr = testutil.GatherAndCompare(run.Metrics, strings.NewReader(expectedMetrics), "zfs_sync_backup_sent_snapshots")
 			if compareErr == nil {
@@ -724,7 +724,7 @@ func TestBackupSendingStateAndMetrics(t *testing.T) {
 	assert.NoError(t, testutil.GatherAndCompare(run.Metrics, strings.NewReader(fmt.Sprintf(`
 # HELP zfs_sync_backup_in_progress_snapshot_deadline The deadline for the current in progress snapshot. Deadline is represented as the number of seconds since January 1, 1970 UTC - same as the Prometheus time() function.
 # TYPE zfs_sync_backup_in_progress_snapshot_deadline gauge
-zfs_sync_backup_in_progress_snapshot_deadline{name=%q,namespace=%q} %d
+zfs_sync_backup_in_progress_snapshot_deadline{resource_name=%q,resource_namespace=%q} %d
 `, someBackup, run.Namespace, run.Clock.Now().Add(2*time.Hour).Unix())), "zfs_sync_backup_in_progress_snapshot_deadline"))
 	receiveResume()
 
@@ -742,6 +742,6 @@ zfs_sync_backup_in_progress_snapshot_deadline{name=%q,namespace=%q} %d
 	assert.NoError(t, testutil.GatherAndCompare(run.Metrics, strings.NewReader(fmt.Sprintf(`
 # HELP zfs_sync_backup_in_progress_snapshot_deadline The deadline for the current in progress snapshot. Deadline is represented as the number of seconds since January 1, 1970 UTC - same as the Prometheus time() function.
 # TYPE zfs_sync_backup_in_progress_snapshot_deadline gauge
-zfs_sync_backup_in_progress_snapshot_deadline{name=%q,namespace=%q} 0
+zfs_sync_backup_in_progress_snapshot_deadline{resource_name=%q,resource_namespace=%q} 0
 `, someBackup, run.Namespace)), "zfs_sync_backup_in_progress_snapshot_deadline"))
 }

--- a/internal/config/alert.rules.yaml
+++ b/internal/config/alert.rules.yaml
@@ -14,9 +14,9 @@ spec:
             severity: critical
           annotations:
             summary: |
-              ZFS Pool {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+              ZFS Pool {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is unhealthy with state {{ $labels.state }}
             description: |
-              ZFS Pool {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+              ZFS Pool {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is unhealthy with state {{ $labels.state }}
         - alert: ZFSBackupUnhealthy
           expr: zfs_sync_backup_state{state!~"Ready|Sending"} > 0
           for: 5m
@@ -24,9 +24,9 @@ spec:
             severity: critical
           annotations:
             summary: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+              ZFS Backup {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is unhealthy with state {{ $labels.state }}
             description: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is unhealthy with state {{ $labels.state }}
+              ZFS Backup {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is unhealthy with state {{ $labels.state }}
         - alert: ZFSBackupNotProgressing
           expr: increase(zfs_sync_backup_sent_bytes[1h]) == 0 and zfs_sync_backup_in_progress_snapshot_deadline != 0
           for: 1h
@@ -34,9 +34,9 @@ spec:
             severity: critical
           annotations:
             summary: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing
+              ZFS Backup {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is not progressing
             description: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is not progressing.
+              ZFS Backup {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is not progressing.
               Data transfer rate has been zero for more than 1 hour.
         - alert: ZFSBackupIsBehindSchedule
           expr: time() - zfs_sync_backup_in_progress_snapshot_deadline > 0 and zfs_sync_backup_in_progress_snapshot_deadline != 0
@@ -45,8 +45,8 @@ spec:
             severity: critical
           annotations:
             summary: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule ({{ $value | humanizeDuration }})
+              ZFS Backup {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is falling behind the snapshot schedule ({{ $value | humanizeDuration }})
             description: |
-              ZFS Backup {{ $labels.namespace }}/{{ $labels.name }} is falling behind the snapshot schedule.
+              ZFS Backup {{ $labels.resource_namespace }}/{{ $labels.resource_name }} is falling behind the snapshot schedule.
               The current snapshot send should have completed sending by now. The deadline was {{ $value | humanizeDuration }} ago.
               Check for a slow or unstable network connection to both source and destination pools.

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -5,8 +5,8 @@ import "github.com/prometheus/client_golang/prometheus"
 
 // Common metric labels
 const (
-	NamespaceLabel = "namespace"
-	NameLabel      = "name"
+	NamespaceLabel = "resource_namespace"
+	NameLabel      = "resource_name"
 	StateLabel     = "state"
 )
 

--- a/internal/pool/reconciler_test.go
+++ b/internal/pool/reconciler_test.go
@@ -149,7 +149,7 @@ config:
 # TYPE zfs_sync_pool_state gauge
 `
 			for state := range zfspool.AllStates() {
-				expectedMetrics += fmt.Sprintf("zfs_sync_pool_state{name=%q,namespace=%q,state=%q} %f\n",
+				expectedMetrics += fmt.Sprintf("zfs_sync_pool_state{resource_name=%q,resource_namespace=%q,state=%q} %f\n",
 					somePoolName,
 					run.Namespace,
 					state.String(),


### PR DESCRIPTION

Fix alert label names to avoid conflicts with Prometheus' built-in namespace labels
