### PR TITLE
Use improved cubic TCP congestion control, disable userspace TCP recovery (RACK)

### DIFF
--- a/internal/netstack/net.go
+++ b/internal/netstack/net.go
@@ -43,9 +43,11 @@ const nicID = 1
 // Useful for avoiding kernel module privilege requirements to manage TUN devices, like with WireGuard.
 func New(localAddresses []netip.Addr, maxTransmissionUnit uint32) (*Net, error) {
 	opts := stack.Options{
-		NetworkProtocols:   []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
-		TransportProtocols: []stack.TransportProtocolFactory{tcp.NewProtocol},
-		HandleLocal:        true,
+		NetworkProtocols: []stack.NetworkProtocolFactory{ipv4.NewProtocol, ipv6.NewProtocol},
+		TransportProtocols: []stack.TransportProtocolFactory{
+			tcp.NewProtocolCUBIC, // Use cubic to less aggressively increase traffic and avoid overwhelming the link. https://github.com/google/gvisor/pull/10287
+		},
+		HandleLocal: true,
 	}
 	const channelEndpointSize = 1 << 10
 	net := &Net{

--- a/internal/netstack/net.go
+++ b/internal/netstack/net.go
@@ -59,6 +59,7 @@ func New(localAddresses []netip.Addr, maxTransmissionUnit uint32) (*Net, error) 
 	}
 	for _, option := range []tcpip.SettableTransportProtocolOption{
 		pointer.Of(tcpip.TCPSACKEnabled(true)),
+		pointer.Of(tcpip.TCPRecovery(0)), // Disable recovery to save some CPU cycles in userspace, defer to kernel and network level recovery.
 	} {
 		if err := net.stack.SetTransportProtocolOption(tcp.ProtocolNumber, option); err != nil {
 			return nil, errors.Errorf("failed to set TCP transport option %v: %v", option, err)


### PR DESCRIPTION

* Use cubic TCP protocol for better congestion handling with high throughput connections
* Disable TCP recovery within netstack, defer to kernel and hardware-level network for recovery

This lifted real-world throughput from KiB to MiB. I don't have benchmarks to prove it, unfortunately. Maybe the existing ones can be improved in the future.
