### PR TITLE
Move read/write of send/receive into pipe structure, add idle timeout

### DIFF
--- a/internal/backup/pipe.go
+++ b/internal/backup/pipe.go
@@ -7,12 +7,18 @@ import (
 	"github.com/johnstarich/zfs-sync-operator/internal/iocount"
 )
 
+// pipe is a readable/writable/closable unbuffered pipe that fails with [io.ErrUnexpectedEOF]
+// when idleTimeout elapses during a Read or Write.
+//
+// The pipe and all connected parts must be thrown away immediately when this error is returned
+// to avoid undefined behavior from retaining the read/write buffer.
 type pipe struct {
 	io.Reader
 	*iocount.Writer
 	idleTimeout time.Duration
 }
 
+// newPipe returns a new [pipe]
 func newPipe(idleTimeout time.Duration) *pipe {
 	r, w := io.Pipe()
 	countWriter := iocount.NewWriter(w)

--- a/internal/backup/pipe.go
+++ b/internal/backup/pipe.go
@@ -1,0 +1,47 @@
+package backup
+
+import (
+	"io"
+	"time"
+
+	"github.com/johnstarich/zfs-sync-operator/internal/iocount"
+)
+
+type pipe struct {
+	io.Reader
+	*iocount.Writer
+	idleTimeout time.Duration
+}
+
+func newPipe(idleTimeout time.Duration) *pipe {
+	r, w := io.Pipe()
+	countWriter := iocount.NewWriter(w)
+	return &pipe{
+		Reader:      r,
+		Writer:      countWriter,
+		idleTimeout: idleTimeout,
+	}
+}
+
+type readResult struct {
+	N   int
+	Err error
+}
+
+func (p *pipe) Read(b []byte) (int, error) {
+	results := make(chan readResult)
+	go func() {
+		// NOTE: This is not ideal. Reading into 'b' after the caller returns has undefined behavior.
+		//
+		// We're making assumptions here to keep client code as simple as possible.
+		// Specifically, we're constraining this to "stuck" scenarios and expecting the buffers to all be thrown away immediately when we time out.
+		n, err := p.Reader.Read(b)
+		results <- readResult{N: n, Err: err}
+	}()
+	select {
+	case result := <-results:
+		return result.N, result.Err
+	case <-time.After(p.idleTimeout):
+		return 0, io.ErrUnexpectedEOF
+	}
+}

--- a/internal/backup/pipe_test.go
+++ b/internal/backup/pipe_test.go
@@ -22,6 +22,7 @@ type fullIOResult struct {
 }
 
 func TestPipeReadWrite(t *testing.T) {
+	t.Parallel()
 	const idleTimeout = 1 * time.Second
 	pipe := newPipe(idleTimeout)
 	const someData = "some data"

--- a/internal/backup/pipe_test.go
+++ b/internal/backup/pipe_test.go
@@ -15,7 +15,7 @@ var _ interface {
 	io.Closer
 } = &pipe{}
 
-type fullReadResult struct {
+type fullIOResult struct {
 	Data []byte
 	N    int
 	Err  error
@@ -44,29 +44,37 @@ func TestPipeReadWrite(t *testing.T) {
 
 func TestPipeIdleTimeout(t *testing.T) {
 	t.Parallel()
-	const idleTimeout = 1 * time.Second
-	pipe := newPipe(idleTimeout)
-	readResults := make(chan fullReadResult)
+	for name, fn := range map[string]func(*pipe, []byte) (int, error){
+		"read":  (*pipe).Read,
+		"write": (*pipe).Write,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			const idleTimeout = 1 * time.Second
+			pipe := newPipe(idleTimeout)
+			readResults := make(chan fullIOResult)
 
-	makeByteArray := func() []byte {
-		return make([]byte, 1)
-	}
+			makeByteArray := func() []byte {
+				return make([]byte, 1)
+			}
 
-	go func() {
-		b := makeByteArray()
-		n, err := pipe.Read(b)
-		readResults <- fullReadResult{
-			Data: b,
-			N:    n,
-			Err:  err,
-		}
-	}()
-	select {
-	case <-time.After(idleTimeout * 2):
-		t.Error("read should time out at", idleTimeout)
-	case result := <-readResults:
-		assert.Equal(t, io.ErrUnexpectedEOF, result.Err)
-		assert.Equal(t, makeByteArray(), result.Data)
-		assert.Zero(t, result.N)
+			go func() {
+				b := makeByteArray()
+				n, err := fn(pipe, b)
+				readResults <- fullIOResult{
+					Data: b,
+					N:    n,
+					Err:  err,
+				}
+			}()
+			select {
+			case <-time.After(idleTimeout * 2):
+				t.Error("should time out at", idleTimeout)
+			case result := <-readResults:
+				assert.Equal(t, io.ErrUnexpectedEOF, result.Err)
+				assert.Equal(t, makeByteArray(), result.Data)
+				assert.Zero(t, result.N)
+			}
+		})
 	}
 }

--- a/internal/backup/pipe_test.go
+++ b/internal/backup/pipe_test.go
@@ -1,0 +1,72 @@
+package backup
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var _ interface {
+	io.Reader
+	io.Writer
+	io.Closer
+} = &pipe{}
+
+type fullReadResult struct {
+	Data []byte
+	N    int
+	Err  error
+}
+
+func TestPipeReadWrite(t *testing.T) {
+	const idleTimeout = 1 * time.Second
+	pipe := newPipe(idleTimeout)
+	const someData = "some data"
+
+	wait, done := context.WithTimeout(context.Background(), idleTimeout*2)
+	t.Cleanup(func() { <-wait.Done() })
+	go func() {
+		n, err := pipe.Write([]byte(someData))
+		assert.NoError(t, err)
+		assert.Equal(t, len(someData), n)
+		done()
+	}()
+
+	b := make([]byte, len(someData))
+	n, err := pipe.Read(b)
+	assert.NoError(t, err)
+	assert.Equal(t, len(someData), n)
+	assert.Equal(t, someData, string(b))
+}
+
+func TestPipeIdleTimeout(t *testing.T) {
+	t.Parallel()
+	const idleTimeout = 1 * time.Second
+	pipe := newPipe(idleTimeout)
+	readResults := make(chan fullReadResult)
+
+	makeByteArray := func() []byte {
+		return make([]byte, 1)
+	}
+
+	go func() {
+		b := makeByteArray()
+		n, err := pipe.Read(b)
+		readResults <- fullReadResult{
+			Data: b,
+			N:    n,
+			Err:  err,
+		}
+	}()
+	select {
+	case <-time.After(idleTimeout * 2):
+		t.Error("read should time out at", idleTimeout)
+	case result := <-readResults:
+		assert.Equal(t, io.ErrUnexpectedEOF, result.Err)
+		assert.Equal(t, makeByteArray(), result.Data)
+		assert.Zero(t, result.N)
+	}
+}


### PR DESCRIPTION

Move read/write of send/receive into pipe structure, add idle timeout.
This is a best-effort fault detection handler, which assumes everything will be tossed out if the connection becomes stuck.

It should be enough to "unstick" busted connections and allow communication to resume on a new SSH connection.

Should fix https://github.com/JohnStarich/zfs-sync-operator/issues/35
