### PR TITLE
Add shutdown context for more graceful SSH connection close before WireGuard teardown

### DIFF
--- a/internal/operator/test_operator.go
+++ b/internal/operator/test_operator.go
@@ -37,10 +37,7 @@ import (
 //		...
 //	}
 func RunTestMain(m *testing.M, storeTestEnv **envtestrunner.Runner) {
-	flag.Parse()
-	if testing.Short() {
-		return
-	}
+	flag.Parse() // allow testing.Short() to work
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 	testEnv := envtestrunner.New(ctx, m.Run, mustNewScheme())
@@ -66,6 +63,11 @@ type TestRunConfig struct {
 // RunTest sets up an [Operator] and a namespace to create resources in. Uses the existing global [envtestrunner.Runner] set up from a [RunTestMain].
 func RunTest(tb testing.TB, testEnv *envtestrunner.Runner) (returnedConfig TestRunConfig) {
 	tb.Helper()
+	if testing.Short() {
+		tb.Skip("Short requested. Skipping longer operator reconcile tests.")
+		return
+	}
+
 	ctx, cancel := context.WithCancel(testEnv.Context())
 	shutdownCtx, shutdownComplete := context.WithCancel(context.Background())
 	tb.Cleanup(func() {

--- a/internal/operator/test_operator.go
+++ b/internal/operator/test_operator.go
@@ -65,7 +65,7 @@ func RunTest(tb testing.TB, testEnv *envtestrunner.Runner) (returnedConfig TestR
 	tb.Helper()
 	if testing.Short() {
 		tb.Skip("Short requested. Skipping longer operator reconcile tests.")
-		return
+		return TestRunConfig{}
 	}
 
 	ctx, cancel := context.WithCancel(testEnv.Context())

--- a/internal/pool/connection_test.go
+++ b/internal/pool/connection_test.go
@@ -1,0 +1,29 @@
+package pool
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestShutdownContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	const shutdownTimeout = 2 * time.Second
+	shutdownCtx := shutdownContext(ctx, shutdownTimeout)
+	cancel()
+	select {
+	case <-time.After(shutdownTimeout / 2):
+		t.Log("did not cancel at the same time as parent ctx")
+	case <-shutdownCtx.Done():
+		t.Error("should not cancel for", shutdownTimeout)
+	}
+	select {
+	case <-time.After(shutdownTimeout):
+		t.Error("failed to cancel after timeout")
+	case <-shutdownCtx.Done():
+		t.Log("canceled successfully after timeout")
+	}
+}


### PR DESCRIPTION

* Add shutdown context for more graceful SSH connection close before WireGuard teardown. Helps avoid hangs like https://github.com/JohnStarich/zfs-sync-operator/issues/35
* Skip long running reconcile tests with -short flag
