### PR TITLE
When pipe is closed due to idle, cancel the send/receive and report the cause

### DIFF
--- a/internal/backup/pipe_test.go
+++ b/internal/backup/pipe_test.go
@@ -83,12 +83,11 @@ func TestPipeIdleTimeout(t *testing.T) {
 
 				n, err := pipe.Read(makeByteArray())
 				assert.Zero(t, n)
-				assert.Error(t, err)
-				assert.NotEqual(t, io.EOF, err)
+				assert.Equal(t, io.EOF, err, "Read should hit EOF after close, since the paired writer is the source; the pipe isn't relevant to the reader")
 				n, err = pipe.Write(makeByteArray())
 				assert.Zero(t, n)
 				assert.Error(t, err)
-				assert.NotEqual(t, io.EOF, err)
+				assert.NotEqual(t, io.EOF, err, "Write should not hit EOF after close, it should return the idle timeout error")
 			}
 		})
 	}

--- a/internal/backup/pipe_test.go
+++ b/internal/backup/pipe_test.go
@@ -75,7 +75,11 @@ func TestPipeIdleTimeout(t *testing.T) {
 				assert.Equal(t, io.ErrUnexpectedEOF, result.Err)
 				assert.Equal(t, makeByteArray(), result.Data)
 				assert.Zero(t, result.N)
-				assert.True(t, pipe.closed.Load())
+				select {
+				case <-pipe.ctx.Done():
+				default:
+					t.Error("pipe not closed after idle")
+				}
 
 				n, err := pipe.Read(makeByteArray())
 				assert.Zero(t, n)

--- a/internal/backup/reconciler.go
+++ b/internal/backup/reconciler.go
@@ -415,10 +415,13 @@ func (r *Reconciler) sendDatasetSnapshot(ctx context.Context, backup *Backup, so
 	}
 	logger.Info("Syncing", "sendCommand", sendArgs, "receiveCommand", receiveArgs)
 
-	const maxExpectedErrors = 2
+	const maxExpectedErrors = 3
 	errs := make(chan error, maxExpectedErrors)
 	const idleTimeout = 30 * time.Second
 	pipe := newPipe(idleTimeout)
+	go func() {
+		errs <- pipe.Wait()
+	}()
 	go func() {
 		errs <- sourceConn.ExecWriteStdout(ctx, pipe, sendArgs[0], sendArgs[1:]...)
 	}()


### PR DESCRIPTION

When pipe is closed due to idle, cancel the send/receive and report the cause
