### PR TITLE
Set upper bound on connect timeout to avoid indefinite hangs

### DIFF
--- a/internal/pool/connection.go
+++ b/internal/pool/connection.go
@@ -171,7 +171,10 @@ func (p *Pool) dialSSHConnection(ctx context.Context, client ctrlclient.Client) 
 		ipNet = wireGuardNet
 	}
 
-	conn, err := ipNet.DialContext(ctx, "tcp", sshAddress)
+	const connectTimeout = 10 * time.Second // Arbitrary upper bound connect timeout to prevent indefinite hangs
+	dialCtx, cancel := context.WithTimeout(ctx, connectTimeout)
+	defer cancel()
+	conn, err := ipNet.DialContext(dialCtx, "tcp", sshAddress)
 	return conn, errors.WithMessagef(err, "dial SSH server %s", sshAddress)
 }
 


### PR DESCRIPTION

Set upper bound on connect timeout to avoid indefinite hangs
This appears to happen if the WireGuard connection stalls at the most inopportune moment.
